### PR TITLE
refactor: Rework MainActivity's view hierarchy to not have NestedScro…

### DIFF
--- a/app/src/main/java/com/jackingaming/vesselforcheesemobileapp/controllers/order/menu/child/SubCategoryAdapter.java
+++ b/app/src/main/java/com/jackingaming/vesselforcheesemobileapp/controllers/order/menu/child/SubCategoryAdapter.java
@@ -122,6 +122,7 @@ public class SubCategoryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHo
             LinearLayoutManager linearLayoutManager = new LinearLayoutManager(rvSubCategory.getContext());
             linearLayoutManager.setOrientation(LinearLayoutManager.HORIZONTAL);
             rvSubCategory.setLayoutManager(linearLayoutManager);
+            rvSubCategory.setNestedScrollingEnabled(false);
         }
 
         @Override

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -35,17 +35,12 @@
         </com.google.android.material.appbar.CollapsingToolbarLayout>
     </com.google.android.material.appbar.AppBarLayout>
 
-    <androidx.core.widget.NestedScrollView
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/fcv_main"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:fillViewport="true"
-        app:layout_behavior="@string/appbar_scrolling_view_behavior">
-
-        <androidx.fragment.app.FragmentContainerView
-            android:id="@+id/fcv_main"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent" />
-    </androidx.core.widget.NestedScrollView>
+        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
     <com.google.android.material.bottomnavigation.BottomNavigationView
         android:id="@+id/bnv_main"

--- a/app/src/main/res/layout/fragment_favorites.xml
+++ b/app/src/main/res/layout/fragment_favorites.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -10,4 +10,4 @@
         android:layout_height="match_parent"
         android:text="Favorites" />
 
-</FrameLayout>
+</androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/layout/fragment_featured.xml
+++ b/app/src/main/res/layout/fragment_featured.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -10,4 +10,4 @@
         android:layout_height="match_parent"
         android:text="Featured" />
 
-</FrameLayout>
+</androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/layout/fragment_gift.xml
+++ b/app/src/main/res/layout/fragment_gift.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -10,4 +10,4 @@
         android:layout_height="match_parent"
         android:text="gift" />
 
-</FrameLayout>
+</androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -10,4 +10,4 @@
         android:layout_height="match_parent"
         android:text="home" />
 
-</FrameLayout>
+</androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/layout/fragment_order.xml
+++ b/app/src/main/res/layout/fragment_order.xml
@@ -20,5 +20,4 @@
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="1" />
-
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_previous.xml
+++ b/app/src/main/res/layout/fragment_previous.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -10,4 +10,4 @@
         android:layout_height="match_parent"
         android:text="Previous" />
 
-</FrameLayout>
+</androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/layout/fragment_scan.xml
+++ b/app/src/main/res/layout/fragment_scan.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -10,4 +10,4 @@
         android:layout_height="match_parent"
         android:text="scan" />
 
-</FrameLayout>
+</androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/layout/fragment_stores.xml
+++ b/app/src/main/res/layout/fragment_stores.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -10,4 +10,4 @@
         android:layout_height="match_parent"
         android:text="stores" />
 
-</FrameLayout>
+</androidx.core.widget.NestedScrollView>


### PR DESCRIPTION
…llView

The main content of MainActivity's view hierarchy is now simply a FragmentContainerView. The layout of the Fragments hosted in this FCV will each have (either) the NestedScrollView (or a RecyclerView [which already has nested scrolling]).

A key part of fixing MenuItemCategoryActivity's collapsing toolbar un-smoothness was calling the following on the nested-RV: "setNestedScrollingEnabled(false)".